### PR TITLE
removed dependency qb-inventory

### DIFF
--- a/Ranjit-EmsBag/fxmanifest.lua
+++ b/Ranjit-EmsBag/fxmanifest.lua
@@ -30,7 +30,6 @@ files {
 
 dependencies {
     'qb-core',
-    'qb-inventory',
     'qb-target'
 }
 


### PR DESCRIPTION
If your using a other Inventory script like lj-inventory it won't work because you don't have qb-inventory but the triggers are the same.